### PR TITLE
Add display(x,y,w,h) method for partial updates

### DIFF
--- a/src/GxEPD2_3C.h
+++ b/src/GxEPD2_3C.h
@@ -147,6 +147,12 @@ class GxEPD2_3C : public Adafruit_GFX
       epd2.refresh(partial_update_mode);
     }
 
+    void display(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+    {
+      epd2.writeImage(_black_buffer, _color_buffer, 0, 0, WIDTH, HEIGHT);
+      epd2.refresh(x, y, w, h);
+    }
+
     void setFullWindow()
     {
       _using_partial_mode = false;

--- a/src/GxEPD2_BW.h
+++ b/src/GxEPD2_BW.h
@@ -148,6 +148,12 @@ class GxEPD2_BW : public Adafruit_GFX
       epd2.refresh(partial_update_mode);
     }
 
+    void display(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+    {
+      epd2.writeImage(_buffer, 0, 0, WIDTH, HEIGHT);
+      epd2.refresh(x, y, w, h);
+    }
+
     void setFullWindow()
     {
       _using_partial_mode = false;

--- a/src/GxEPD2_GFX.h
+++ b/src/GxEPD2_GFX.h
@@ -12,6 +12,8 @@
 #ifndef _GxEPD2_GFX_H_
 #define _GxEPD2_GFX_H_
 
+#include "GxEPD2_EPD.h"
+
 #include <Adafruit_GFX.h>
 
 class GxEPD2_GFX : public Adafruit_GFX
@@ -30,11 +32,12 @@ class GxEPD2_GFX : public Adafruit_GFX
     virtual void init(uint32_t serial_diag_bitrate, bool initial, bool pulldown_rst_mode = false) = 0;
     virtual void fillScreen(uint16_t color) = 0; // 0x0 black, >0x0 white, to buffer
     virtual void display(bool partial_update_mode = false) = 0;
+    virtual void display(uint16_t x, uint16_t y, uint16_t w, uint16_t h) = 0;
     virtual void setFullWindow() = 0;
     // setPartialWindow, use parameters according to actual rotation.
     // x and w should be multiple of 8, for rotation 0 or 2,
     // y and h should be multiple of 8, for rotation 1 or 3,
-    // else window is increased as needed, 
+    // else window is increased as needed,
     // this is an addressing limitation of the e-paper controllers
     virtual void setPartialWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) = 0;
     virtual void firstPage() = 0;


### PR DESCRIPTION
Forgive me if there's already a way to do this, but wasn't obvious to me what it is.  The situation I'm in is:

* My project requires the full frame buffer to be in memory.
* It also requires partial updates
* As far as I could tell, the way to work with full frames in memory is to use the `display(bool)` method, which does not support regional updates.

Basically I need something that:

* Flushes the frame buffer
* Calls the partial update version of `refresh`

Added it here.  Happy to add an example if that'd be worthwhile.

Tested with my project, working great.