### PR TITLE
Increase SPI baudrate of 4.2" e-paper to 10MHz

### DIFF
--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -18,10 +18,10 @@
 #endif
 
 GxEPD2_EPD::GxEPD2_EPD(int8_t cs, int8_t dc, int8_t rst, int8_t busy, int8_t busy_level, uint32_t busy_timeout,
-                       uint16_t w, uint16_t h, GxEPD2::Panel p, bool c, bool pu, bool fpu) :
+                       uint16_t w, uint16_t h, GxEPD2::Panel p, bool c, bool pu, bool fpu, uint32_t spi_max_baud) :
   WIDTH(w), HEIGHT(h), panel(p), hasColor(c), hasPartialUpdate(pu), hasFastPartialUpdate(fpu),
   _cs(cs), _dc(dc), _rst(rst), _busy(busy), _busy_level(busy_level), _busy_timeout(busy_timeout), _diag_enabled(false),
-  _spi_settings(4000000, MSBFIRST, SPI_MODE0)
+  _spi_settings(spi_max_baud, MSBFIRST, SPI_MODE0)
 {
   _initial_write = true;
   _initial_refresh = true;

--- a/src/GxEPD2_EPD.h
+++ b/src/GxEPD2_EPD.h
@@ -31,7 +31,7 @@ class GxEPD2_EPD
     const bool hasFastPartialUpdate;
     // constructor
     GxEPD2_EPD(int8_t cs, int8_t dc, int8_t rst, int8_t busy, int8_t busy_level, uint32_t busy_timeout,
-               uint16_t w, uint16_t h, GxEPD2::Panel p, bool c, bool pu, bool fpu);
+               uint16_t w, uint16_t h, GxEPD2::Panel p, bool c, bool pu, bool fpu, uint32_t spi_max_baud=4000000);
     virtual void init(uint32_t serial_diag_bitrate = 0); // serial_diag_bitrate = 0 : disabled
     virtual void init(uint32_t serial_diag_bitrate, bool initial, bool pulldown_rst_mode = false);
     //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen

--- a/src/epd/GxEPD2_420.cpp
+++ b/src/epd/GxEPD2_420.cpp
@@ -13,7 +13,7 @@
 #include "GxEPD2_420.h"
 
 GxEPD2_420::GxEPD2_420(int8_t cs, int8_t dc, int8_t rst, int8_t busy) :
-  GxEPD2_EPD(cs, dc, rst, busy, LOW, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+  GxEPD2_EPD(cs, dc, rst, busy, LOW, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate, 10000000)
 {
 }
 


### PR DESCRIPTION
According to the [Waveshare datasheet](https://www.waveshare.com/w/upload/6/6a/4.2inch-e-paper-specification.pdf), the 4.2" e-paper can handle SPI clocks up to 10 MHz. (100ns serial clock cycle).

When the base class `GxEPD2_EPD` has an additional constructor argument for SPI baud rate, with 4MHz as default value, then implementations for faster displays can fine tune this value, while those for slower ones don't need to be changed.