### PR TITLE
Use SPI bulk writes for image data on the 4.2" display

### DIFF
--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -222,3 +222,20 @@ void GxEPD2_EPD::_writeCommandDataPGM(const uint8_t* pCommandData, uint8_t datal
   if (_cs >= 0) digitalWrite(_cs, HIGH);
   SPI.endTransaction();
 }
+
+void GxEPD2_EPD::_beginWriteDataBulk()
+{
+  SPI.beginTransaction(_spi_settings);
+  if (_cs >= 0) digitalWrite(_cs, LOW);
+}
+
+void GxEPD2_EPD::_doWriteDataBulk(uint8_t d)
+{
+  SPI.transfer(d);
+}
+
+void GxEPD2_EPD::_endWriteDataBulk()
+{
+  if (_cs >= 0) digitalWrite(_cs, HIGH);
+  SPI.endTransaction();
+}

--- a/src/GxEPD2_EPD.h
+++ b/src/GxEPD2_EPD.h
@@ -91,6 +91,9 @@ class GxEPD2_EPD
     void _writeDataPGM_sCS(const uint8_t* data, uint16_t n, int16_t fill_with_zeroes = 0);
     void _writeCommandData(const uint8_t* pCommandData, uint8_t datalen);
     void _writeCommandDataPGM(const uint8_t* pCommandData, uint8_t datalen);
+    void _beginWriteDataBulk();
+    void _doWriteDataBulk(uint8_t d);
+    void _endWriteDataBulk();
   protected:
     int8_t _cs, _dc, _rst, _busy, _busy_level;
     uint32_t _busy_timeout;

--- a/src/epd/GxEPD2_420.cpp
+++ b/src/epd/GxEPD2_420.cpp
@@ -31,16 +31,20 @@ void GxEPD2_420::writeScreenBuffer(uint8_t value)
   if (_initial_refresh)
   {
     _writeCommand(0x10); // init old data
+    _beginWriteDataBulk();
     for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
     {
-      _writeData(value);
+      _doWriteDataBulk(value);
     }
+    _endWriteDataBulk();
   }
   _writeCommand(0x13);
+  _beginWriteDataBulk();
   for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
   {
-    _writeData(value);
+    _doWriteDataBulk(value);
   }
+  _endWriteDataBulk();
 }
 
 void GxEPD2_420::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
@@ -63,6 +67,7 @@ void GxEPD2_420::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_
   _writeCommand(0x91); // partial in
   _setPartialRamArea(x1, y1, w1, h1);
   _writeCommand(0x13);
+  _beginWriteDataBulk();
   for (int16_t i = 0; i < h1; i++)
   {
     for (int16_t j = 0; j < w1 / 8; j++)
@@ -83,9 +88,10 @@ void GxEPD2_420::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_
         data = bitmap[idx];
       }
       if (invert) data = ~data;
-      _writeData(data);
+      _doWriteDataBulk(data);
     }
   }
+  _endWriteDataBulk();
   _writeCommand(0x92); // partial out
   delay(1); // yield() to avoid WDT on ESP8266 and ESP32
 }
@@ -117,6 +123,7 @@ void GxEPD2_420::writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t 
   _writeCommand(0x91); // partial in
   _setPartialRamArea(x1, y1, w1, h1);
   _writeCommand(0x13);
+  _beginWriteDataBulk();
   for (int16_t i = 0; i < h1; i++)
   {
     for (int16_t j = 0; j < w1 / 8; j++)
@@ -137,9 +144,10 @@ void GxEPD2_420::writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t 
         data = bitmap[idx];
       }
       if (invert) data = ~data;
-      _writeData(data);
+      _doWriteDataBulk(data);
     }
   }
+  _endWriteDataBulk();
   _writeCommand(0x92); // partial out
   delay(1); // yield() to avoid WDT on ESP8266 and ESP32
 }


### PR DESCRIPTION
`GxEPD2_EPD` transfers the image data byte-wise using `_writeData()`, initiating a new SPI transaction for each and every byte.
This patch proposes an API where the display implementation can explicitly start and finish a SPI transfer, so the write access of e.g. `writeImage` can be consolidated into a single transaction, making it more efficient.

I tested it on a Arduino Nano with a Waveshare 4.2" display, where it saves roughly half a second (500ms) for a full screen partial refresh. YMMV.
Porting to other display implementations should be straight forward, see patch to `GxEPD2_420` class.

Test code:
```
display.setRotation(0);
display.setFont(&FreeMonoBold9pt7b);
display.setTextColor(GxEPD_BLACK);
display.setPartialWindow(0, 0, display.width(), display.height());

unsigned long start = micros();
display.firstPage();
do {
    display.fillScreen(GxEPD_WHITE);
    display.setCursor(10, 15);
    display.print("Hello World");
} while (display.nextPage());
unsigned long elapsed = micros() - start;
Serial.print("time spent - w/o refresh: ");
Serial.print(elapsed - 560000);
Serial.println(" us");
Serial.print("time spent - total: ");
Serial.print(elapsed);
Serial.println(" us");

```
Test code output using SPI single writes:

```
_Update_Part : 560704
time spent - w/o refresh: 1157560 us
time spent - total: 1717560 us

```
Test code output using SPI bulk writes:
```

_Update_Part : 560800
time spent - w/o refresh: 651488 us
time spent - total: 1211488 us
```


