### PR TITLE
added support for B72B (LilyGo T5 2.13)

### DIFF
--- a/src/GxEPD2.h
+++ b/src/GxEPD2.h
@@ -33,6 +33,7 @@ class GxEPD2
       GDEH0154D67, Waveshare_1_54_bw_D67 = GDEH0154D67,
       GDE0213B1,  Waveshare_2_13_bw = GDE0213B1,
       GDEH0213B72,  Waveshare_2_13_bw_B72 = GDEH0213B72,
+      GDEH0213B72B,
       GDEH0213B73,  Waveshare_2_13_bw_B73 = GDEH0213B73,
       GDEW0213I5F, Waveshare_2_13_flex = GDEW0213I5F,
       GDEW026T0,  Waveshare_2_6_bw = GDEW026T0,

--- a/src/GxEPD2_BW.h
+++ b/src/GxEPD2_BW.h
@@ -18,6 +18,7 @@
 #include "epd/GxEPD2_154_D67.h"
 #include "epd/GxEPD2_213.h"
 #include "epd/GxEPD2_213_B72.h"
+#include "epd/GxEPD2_213_B72B.h"
 #include "epd/GxEPD2_213_B73.h"
 #include "epd/GxEPD2_213_flex.h"
 #include "epd/GxEPD2_260.h"

--- a/src/epd/GxEPD2_213_B72B.cpp
+++ b/src/epd/GxEPD2_213_B72B.cpp
@@ -1,0 +1,437 @@
+// Display Library for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
+// Requires HW SPI and Adafruit_GFX. Caution: these e-papers require 3.3V supply AND data lines!
+//
+// based on the implementation of GxEPD2_213_B72 and modified for B72B version
+// Example of a display that requires this driver is LilyGO T5 2.13" https://github.com/Xinyuan-LilyGO/LilyGO_T5_V24
+//
+// Author: Jean-Marc Zingg; modified for B72B by Matjaž Depolli (using B72B implementation from https://github.com/lewisxhe/GxEPD) 
+//
+// Version: see library.properties
+//
+// Library: https://github.com/ZinggJM/GxEPD2
+
+#include "GxEPD2_213_B72B.h"
+
+GxEPD2_213_B72B::GxEPD2_213_B72B(int8_t cs, int8_t dc, int8_t rst, int8_t busy) :
+  GxEPD2_EPD(cs, dc, rst, busy, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+{
+}
+
+void GxEPD2_213_B72B::clearScreen(uint8_t value)
+{
+  writeScreenBuffer(value);
+  refresh(true);
+  writeScreenBufferAgain(value);
+}
+
+void GxEPD2_213_B72B::writeScreenBuffer(uint8_t value)
+{
+  _initial_write = false; // initial full screen buffer clean done
+  if (!_using_partial_mode) _Init_Part();
+  _setPartialRamArea(0, 0, WIDTH, HEIGHT);
+  _writeCommand(0x24);
+  for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
+  {
+    _writeData(value);
+  }
+  if (_initial_refresh) writeScreenBufferAgain(value); // init "old data"
+}
+
+void GxEPD2_213_B72B::writeScreenBufferAgain(uint8_t value)
+{
+  if (!_using_partial_mode) _Init_Part();
+  _setPartialRamArea(0, 0, WIDTH, HEIGHT);
+  _writeCommand(0x26);
+  for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
+  {
+    _writeData(value);
+  }
+}
+
+void GxEPD2_213_B72B::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_213_B72B::writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImage(0x26, bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_213_B72B::_writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (_initial_write) writeScreenBuffer(); // initial full screen buffer clean
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+  int16_t wb = (w + 7) / 8; // width bytes, bitmaps are padded
+  x -= x % 8; // byte boundary
+  w = wb * 8; // byte boundary
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  int16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x; // limit
+  int16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0)) return;
+  if (!_using_partial_mode) _Init_Part();
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(command);
+  for (int16_t i = 0; i < h1; i++)
+  {
+    for (int16_t j = 0; j < w1 / 8; j++)
+    {
+      uint8_t data;
+      // use wb, h of bitmap for index!
+      int16_t idx = mirror_y ? j + dx / 8 + ((h - 1 - (i + dy))) * wb : j + dx / 8 + (i + dy) * wb;
+      if (pgm)
+      {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&bitmap[idx]);
+#else
+        data = bitmap[idx];
+#endif
+      }
+      else
+      {
+        data = bitmap[idx];
+      }
+      if (invert) data = ~data;
+      _writeData(data);
+    }
+  }
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_213_B72B::writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                    int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImagePart(0x24, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_213_B72B::writeImagePartAgain(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+    int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImagePart(0x26, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_213_B72B::_writeImagePart(uint8_t command, const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                     int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (_initial_write) writeScreenBuffer(); // initial full screen buffer clean
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+  if ((w_bitmap < 0) || (h_bitmap < 0) || (w < 0) || (h < 0)) return;
+  if ((x_part < 0) || (x_part >= w_bitmap)) return;
+  if ((y_part < 0) || (y_part >= h_bitmap)) return;
+  int16_t wb_bitmap = (w_bitmap + 7) / 8; // width bytes, bitmaps are padded
+  x_part -= x_part % 8; // byte boundary
+  w = w_bitmap - x_part < w ? w_bitmap - x_part : w; // limit
+  h = h_bitmap - y_part < h ? h_bitmap - y_part : h; // limit
+  x -= x % 8; // byte boundary
+  w = 8 * ((w + 7) / 8); // byte boundary, bitmaps are padded
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  int16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x; // limit
+  int16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0)) return;
+  if (!_using_partial_mode) _Init_Part();
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(command);
+  for (int16_t i = 0; i < h1; i++)
+  {
+    for (int16_t j = 0; j < w1 / 8; j++)
+    {
+      uint8_t data;
+      // use wb_bitmap, h_bitmap of bitmap for index!
+      int16_t idx = mirror_y ? x_part / 8 + j + dx / 8 + ((h_bitmap - 1 - (y_part + i + dy))) * wb_bitmap : x_part / 8 + j + dx / 8 + (y_part + i + dy) * wb_bitmap;
+      if (pgm)
+      {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&bitmap[idx]);
+#else
+        data = bitmap[idx];
+#endif
+      }
+      else
+      {
+        data = bitmap[idx];
+      }
+      if (invert) data = ~data;
+      _writeData(data);
+    }
+  }
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_213_B72B::writeImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    writeImage(black, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_213_B72B::writeImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                    int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    writeImagePart(black, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_213_B72B::writeNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (data1)
+  {
+    writeImage(data1, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_213_B72B::drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImage(bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImageAgain(bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_213_B72B::drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImagePart(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImagePartAgain(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_213_B72B::drawImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    drawImage(black, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_213_B72B::drawImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    drawImagePart(black, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_213_B72B::drawNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (data1)
+  {
+    drawImage(data1, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_213_B72B::refresh(bool partial_update_mode)
+{
+  if (partial_update_mode) refresh(0, 0, WIDTH, HEIGHT);
+  else
+  {
+    if (_using_partial_mode) _Init_Full();
+    _Update_Full();
+    _initial_refresh = false; // initial full update done
+  }
+}
+
+void GxEPD2_213_B72B::refresh(int16_t x, int16_t y, int16_t w, int16_t h)
+{
+  if (_initial_refresh) return refresh(false); // initial update needs be full update
+  x -= x % 8; // byte boundary
+  w -= x % 8; // byte boundary
+  int16_t x1 = x < 0 ? 0 : x; // limit
+  int16_t y1 = y < 0 ? 0 : y; // limit
+  int16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x; // limit
+  int16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  w1 -= x1 - x;
+  h1 -= y1 - y;
+  if (!_using_partial_mode) _Init_Part();
+  _setPartialRamArea(x1, y1, w1, h1);
+  _Update_Part();
+}
+
+void GxEPD2_213_B72B::powerOff(void)
+{
+  _PowerOff();
+}
+
+void GxEPD2_213_B72B::hibernate()
+{
+  _PowerOff();
+  if (_rst >= 0)
+  {
+    _writeCommand(0x10); // deep sleep mode
+    _writeData(0x1);     // enter deep sleep
+    _hibernating = true;
+  }
+}
+
+void GxEPD2_213_B72B::_setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+{
+  _writeCommand(0x11); // set ram entry mode
+  _writeData(0x03);    // x increase, y increase : normal mode
+  _writeCommand(0x44);
+  _writeData(x / 8);
+  _writeData((x + w - 1) / 8);
+  _writeCommand(0x45);
+  _writeData(y % 256);
+  _writeData(y / 256);
+  _writeData((y + h - 1) % 256);
+  _writeData((y + h - 1) / 256);
+  _writeCommand(0x4e);
+  _writeData(x / 8);
+  _writeCommand(0x4f);
+  _writeData(y % 256);
+  _writeData(y / 256);
+}
+
+void GxEPD2_213_B72B::_PowerOn()
+{
+  if (!_power_is_on)
+  {
+    _writeCommand(0x22);
+    _writeData(0xc0);
+    _writeCommand(0x20);
+    _waitWhileBusy("_PowerOn", power_on_time);
+  }
+  _power_is_on = true;
+}
+
+void GxEPD2_213_B72B::_PowerOff()
+{
+  _writeCommand(0x22);
+  _writeData(0xc3);
+  _writeCommand(0x20);
+  _waitWhileBusy("_PowerOff", power_off_time);
+  _power_is_on = false;
+  _using_partial_mode = false;
+}
+
+const uint8_t LUTDefault_full[] PROGMEM = {
+    0x32,  // command
+    0xA0,   0x90,   0x50,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0x50,   0x90,   0xA0,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0xA0,   0x90,   0x50,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0x50,   0x90,   0xA0,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+
+    0x0F,   0x0F,   0x00,   0x00,   0x00,
+    0x0F,   0x0F,   0x00,   0x00,   0x03,
+    0x0F,   0x0F,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+
+    0x17,   0x41,   0xA8,   0x32,   0x50, 0x0A, 0x09,
+};
+
+const uint8_t LUTDefault_part[] PROGMEM = {
+    0x32,  // command
+    0x40,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0x80,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0x40,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0x80,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,   0x00,
+
+    0x0A,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x00,   0x00,   0x00,   0x00,   0x00,
+    0x15,   0x41,   0xA8,   0x32,   0x50,   0x2C, 0x0B,
+};
+
+void GxEPD2_213_B72B::_InitDisplay()
+{
+  if (_hibernating) _reset();
+  // Added by MD
+  _waitWhileBusy("_initDisplay");
+  _writeCommand(0x12); 
+  _waitWhileBusy("_initDisplay");
+
+  _writeCommand(0x74); //set analog block control
+  _writeData(0x54);
+  _writeCommand(0x7E); //set digital block control
+  _writeData(0x3B);
+
+  _writeCommand(0x01); //Driver output control
+  _writeData(0xF9);    // (HEIGHT - 1) % 256
+  _writeData(0x00);    // (HEIGHT - 1) / 256
+  _writeData(0x00);
+  
+  _setPartialRamArea(0, 0, WIDTH, HEIGHT);
+
+  _writeCommand(0x3C); //BorderWavefrom
+  _writeData(0x03);
+  
+  _writeCommand(0x2C); //VCOM Voltage
+  _writeData(0x50);    // NA ?? (70 -> 50 changed by MD)
+
+  _writeCommand(0x03); //Gate Driving voltage Control
+  _writeData(0x17);    // (15 -> 17 changed by MD)
+  
+  _writeCommand(0x04); //Source Driving voltage Control
+  _writeData(0x41);    // VSH1 15V
+  _writeData(0xA8);    // VSH2 5V
+  _writeData(0x32);    // VSL -15V
+  
+  _writeCommand(0x3A); //Dummy Line
+  _writeData(0x0A);   // 30 -> 0A changed by MD
+  
+  _writeCommand(0x3B); //Gate time
+  _writeData(0x09);   // 0A -> 09 changed by MD
+
+  _waitWhileBusy("_InitDisplay");
+}
+
+void GxEPD2_213_B72B::_Init_Full()
+{
+  _InitDisplay();
+  _writeCommandDataPGM(LUTDefault_full, sizeof(LUTDefault_full));
+  _PowerOn();
+  _using_partial_mode = false;
+}
+
+void GxEPD2_213_B72B::_Init_Part()
+{
+  _InitDisplay();
+//  _writeCommand(0x2C); //VCOM Voltage
+//  _writeData(0x26);    // NA ??
+  _writeCommandDataPGM(LUTDefault_part, sizeof(LUTDefault_part));
+  _PowerOn();
+  _using_partial_mode = true;
+}
+
+void GxEPD2_213_B72B::_Update_Full()
+{
+  _writeCommand(0x22);
+  _writeData(0xC7);
+  _writeCommand(0x20);
+  _waitWhileBusy("_Update_Full", full_refresh_time);
+}
+
+void GxEPD2_213_B72B::_Update_Part()
+{
+  _writeCommand(0x22);
+  _writeData(0x04);
+  _writeCommand(0x20);
+  _waitWhileBusy("_Update_Part", partial_refresh_time);
+}

--- a/src/epd/GxEPD2_213_B72B.h
+++ b/src/epd/GxEPD2_213_B72B.h
@@ -1,0 +1,82 @@
+// Display Library for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
+// Requires HW SPI and Adafruit_GFX. Caution: these e-papers require 3.3V supply AND data lines!
+//
+// based on Demo Example from Good Display: http://www.e-paper-display.com/download_list/downloadcategoryid=34&isMode=false.html
+// Controller: IL3897 :
+//
+// Author: Jean-Marc Zingg
+//
+// Version: see library.properties
+//
+// Library: https://github.com/ZinggJM/GxEPD2
+
+#ifndef _GxEPD2_213_B72B_H_
+#define _GxEPD2_213_B72B_H_
+
+#include "../GxEPD2_EPD.h"
+
+class GxEPD2_213_B72B : public GxEPD2_EPD
+{
+  public:
+    // attributes
+    static const uint16_t WIDTH = 128;
+    static const uint16_t HEIGHT = 250;
+    static const GxEPD2::Panel panel = GxEPD2::GDEH0213B72B;
+    static const bool hasColor = false;
+    static const bool hasPartialUpdate = true;
+    static const bool hasFastPartialUpdate = true;
+    static const uint16_t power_on_time = 100; // ms, e.g. 91291us
+    static const uint16_t power_off_time = 180; // ms, e.g. 172648us
+    static const uint16_t full_refresh_time = 1700; // ms, e.g. 1686008us
+    static const uint16_t partial_refresh_time = 200; // ms, e.g. 192385us
+    // constructor
+    GxEPD2_213_B72B(int8_t cs, int8_t dc, int8_t rst, int8_t busy);
+    // methods (virtual)
+    //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen
+    void clearScreen(uint8_t value = 0xFF); // init controller memory and screen (default white)
+    void writeScreenBuffer(uint8_t value = 0xFF); // init controller memory (default white)
+    void writeScreenBufferAgain(uint8_t value = 0xFF); // init previous buffer controller memory (default white)
+    // write to controller memory, without screen refresh; x and w should be multiple of 8
+    void writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    // for differential update: set current and previous buffers equal (for fast partial update to work correctly)
+    void writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImagePartAgain(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                             int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    // write sprite of native data to controller memory, without screen refresh; x and w should be multiple of 8
+    void writeNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    // write to controller memory, with screen refresh; x and w should be multiple of 8
+    void drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImage(const uint8_t* black, const uint8_t* color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImagePart(const uint8_t* black, const uint8_t* color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    // write sprite of native data to controller memory, with screen refresh; x and w should be multiple of 8
+    void drawNative(const uint8_t* data1, const uint8_t* data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void refresh(bool partial_update_mode = false); // screen refresh from controller memory to full screen
+    void refresh(int16_t x, int16_t y, int16_t w, int16_t h); // screen refresh from controller memory, partial screen
+    void powerOff(); // turns off generation of panel driving voltages, avoids screen fading over time
+    void hibernate(); // turns powerOff() and sets controller to deep sleep for minimum power use, ONLY if wakeable by RST (rst >= 0)
+  private:
+    void _writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void _writeImagePart(uint8_t command, const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                         int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+    void _setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+    void _PowerOn();
+    void _PowerOff();
+    void _InitDisplay();
+    void _Init_Full();
+    void _Init_Part();
+    void _Update_Full();
+    void _Update_Part();
+  private:
+    static const uint8_t LUT_DATA_full[];
+    static const uint8_t LUT_DATA_part[];
+};
+
+#endif


### PR DESCRIPTION
I added the support for 2.13" LilyGo T5 display (see here [https://github.com/Xinyuan-LilyGO/LilyGO_T5_V24](https://github.com/Xinyuan-LilyGO/LilyGO_T5_V24)).
As a source, I used the fork of GxEPD, where a similar driver was added, and existing code.