### PR TITLE
Fix more strict esp32 defaults

### DIFF
--- a/src/epd/GxEPD2_1248.h
+++ b/src/epd/GxEPD2_1248.h
@@ -121,8 +121,8 @@ class GxEPD2_1248 : public GxEPD2_EPD
       public:
         const uint16_t WIDTH, HEIGHT;
       private:
-        int8_t _cs, _dc;
         bool _rev_scan;
+        int8_t _cs, _dc;
         const SPISettings _spi_settings;
     };
     ScreenPart M1, S1, M2, S2;


### PR DESCRIPTION
```
src/epd/GxEPD2_1248.h:125:14: error: 'GxEPD2_1248::ScreenPart::_rev_scan' will be initialized after [-Werror=reorder]
         bool _rev_scan;
              ^
src/epd/GxEPD2_1248.h:124:16: error:   'int8_t GxEPD2_1248::ScreenPart::_cs' [-Werror=reorder]
         int8_t _cs, _dc;
```

ref: https://github.com/platformio/platform-espressif32/issues/233