### PR TITLE
Update GxEPD2_750_T7.cpp

### DIFF
--- a/src/epd/GxEPD2_750_T7.cpp
+++ b/src/epd/GxEPD2_750_T7.cpp
@@ -14,7 +14,7 @@
 #include "GxEPD2_750_T7.h"
 
 GxEPD2_750_T7::GxEPD2_750_T7(int8_t cs, int8_t dc, int8_t rst, int8_t busy) :
-  GxEPD2_EPD(cs, dc, rst, busy, LOW, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+  GxEPD2_EPD(cs, dc, rst, busy, LOW, 20000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
 {
 }
 


### PR DESCRIPTION
Busy timeout isn't enough for this display. Doubling of time seems to be enough