### PR TITLE
Update GxEPD2_BW.h

### DIFF
--- a/src/GxEPD2_BW.h
+++ b/src/GxEPD2_BW.h
@@ -59,7 +59,7 @@
 #include "it8951/GxEPD2_it60.h"
 #include "it8951/GxEPD2_it60_1448x1072.h"
 
-template<typename GxEPD2_Type, const uint16_t page_height>
+template<typename GxEPD2_Type, const uint16_t page_height = GxEPD2_Type::HEIGHT>
 class GxEPD2_BW : public GxEPD2_GFX_BASE_CLASS
 {
   public:


### PR DESCRIPTION
Hello,
In the template declaration, I would recommend you to add default value as "HEIGHT of template type" .
Apparently this constant exists in each type of GxEPD2 so it might be used without visible risk. 

The benefit of it is that declaration becomes simpler while keeping backward compatibility. 
bellow declaration of 'display' are then equal:
GxEPD2_BW<GxEPD2_154_D67, GxEPD2_154_D67::HEIGHT> display(GxEPD2_154_D67(cs, dc, rst, bsy));
GxEPD2_BW<GxEPD2_154_D67> display(GxEPD2_154_D67(cs, dc, rst, bsy));

regards,
Marc