### PR TITLE
Remove temporary instance of EDP in constructor

### DIFF
--- a/src/it8951/GxEPD2_it60.cpp
+++ b/src/it8951/GxEPD2_it60.cpp
@@ -90,7 +90,7 @@ void GxEPD2_it60::init(uint32_t serial_diag_bitrate, bool initial, uint16_t rese
     printf("Panel(W,H) = (%d,%d)\r\n",
            IT8951DevInfo.usPanelW, IT8951DevInfo.usPanelH );
     printf("Image Buffer Address = %X\r\n",
-           IT8951DevInfo.usImgBufAddrL | (IT8951DevInfo.usImgBufAddrH << 16));
+           uint32_t(IT8951DevInfo.usImgBufAddrL) | (uint32_t(IT8951DevInfo.usImgBufAddrH) << 16));
     //Show Firmware and LUT Version
     printf("FW Version = %s\r\n", (uint8_t*)IT8951DevInfo.usFWVersion);
     printf("LUT Version = %s\r\n", (uint8_t*)IT8951DevInfo.usLUTVersion);


### PR DESCRIPTION
Hello JM,
the suggested changes :

add `GxEPD2_Type::HEIGHT` as default value to the template header so, if omitted, the height is full screen.
Create a template constructor so there is no use to create an instance of `GxEPD2_Type` and pass it to the constructor of `GxEPD2_BW`, it is done at once.
with these two changes one may declare
`GxEPD2_BW<GxEPD2_154_D67> display(cs, dc, rst, bsy);`
It gets much easier to read and even more efficient as no instance of `GxEPD2_154_D67` is temporarily created.

Marc