### PR TITLE
Fix GxEPD2_WiFi_Example bug - gotmore > 0

### DIFF
--- a/examples/GxEPD2_WiFi_Example/GxEPD2_WiFi_Example.ino
+++ b/examples/GxEPD2_WiFi_Example/GxEPD2_WiFi_Example.ino
@@ -583,7 +583,7 @@ void showBitmapFrom_HTTP(const char* host, const char* path, const char* filenam
                 //Serial.print("got "); Serial.print(got); Serial.print(" < "); Serial.print(get); Serial.print(" @ "); Serial.println(bytes_read);
                 uint32_t gotmore = read8n(client, input_buffer + got, get - got);
                 got += gotmore;
-                connection_ok = gotmore > 0;
+                connection_ok = gotmore >= 0;
               }
               in_bytes = got;
               in_remain -= got;
@@ -812,7 +812,7 @@ void drawBitmapFrom_HTTP_ToBuffer(const char* host, const char* path, const char
                 //Serial.print("got "); Serial.print(got); Serial.print(" < "); Serial.print(get); Serial.print(" @ "); Serial.println(bytes_read);
                 uint32_t gotmore = read8n(client, input_buffer + got, get - got);
                 got += gotmore;
-                connection_ok = gotmore > 0;
+                connection_ok = gotmore >= 0;
               }
               in_bytes = got;
               in_remain -= got;
@@ -1062,7 +1062,7 @@ void showBitmapFrom_HTTPS(const char* host, const char* path, const char* filena
                 //if ((get - got) > client.available()) delay(200); // does improve? yes, if >= 200
                 uint32_t gotmore = read8n(client, input_buffer + got, get - got);
                 got += gotmore;
-                connection_ok = gotmore > 0;
+                connection_ok = gotmore >= 0;
               }
               in_bytes = got;
               in_remain -= got;
@@ -1300,7 +1300,7 @@ void drawBitmapFrom_HTTPS_ToBuffer(const char* host, const char* path, const cha
                 //Serial.print("got "); Serial.print(got); Serial.print(" < "); Serial.print(get); Serial.print(" @ "); Serial.println(bytes_read);
                 uint32_t gotmore = read8n(client, input_buffer + got, get - got);
                 got += gotmore;
-                connection_ok = gotmore > 0;
+                connection_ok = gotmore >= 0;
               }
               in_bytes = got;
               in_remain -= got;


### PR DESCRIPTION
Why is the Issues section disabled on this git repo?

Anyway, in the Wifi example, the following lines cause
unpredictable failure loading the complete image. The
image will almost always not load completely, and part
of the top of it will be cut off. It will load fully
maybe once every 20 times, it's not working at all:

```
connection_ok = gotmore > 0;
```

This commit works around the issue by changing it to:

```
connection_ok = gotmore >= 0;
```

It seems to work perfectly, although it might not
be exactly what you wanted to be doing there. Maybe
you'd prefer to fix the logic some other way.

The issue is happening on my Waveshare 640x384 7.5"
b/w display with the GxEPD2_750 driver define
activated.

Please fix it either with this commit or however
you'd prefer, and please also enable the Issues
section on your git repo.