### PR TITLE
Configurable reset delay and busy wait

### DIFF
--- a/src/GxEPD2_BW.h
+++ b/src/GxEPD2_BW.h
@@ -154,9 +154,9 @@ class GxEPD2_BW : public GxEPD2_GFX_BASE_CLASS
     // NOTE: garbage will result on fast partial update displays, if initial full update is omitted after power loss
     // reset_duration = 20 is default; a value of 2 may help with "clever" reset circuit of newer boards from Waveshare 
     // pulldown_rst_mode true for alternate RST handling to avoid feeding 5V through RST pin
-    void init(uint32_t serial_diag_bitrate, bool initial, uint16_t reset_duration = 20, bool pulldown_rst_mode = false)
+    void init(uint32_t serial_diag_bitrate, bool initial, uint16_t reset_duration = 20, bool pulldown_rst_mode = false, uint16_t reset_delay = 200, bool light_sleep = false)
     {
-      epd2.init(serial_diag_bitrate, initial, reset_duration, pulldown_rst_mode);
+      epd2.init(serial_diag_bitrate, initial, reset_duration, pulldown_rst_mode, reset_delay, light_sleep);
       _using_partial_mode = false;
       _current_page = 0;
       setFullWindow();

--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -246,6 +246,13 @@ void GxEPD2_EPD::_transfer(uint8_t value)
   SPI.transfer(value);
 }
 
+void GxEPD2_EPD::_transferCommand(uint8_t value)
+{
+  if (_dc >= 0) digitalWrite(_dc, LOW);
+  SPI.transfer(value);
+  if (_dc >= 0) digitalWrite(_dc, HIGH);
+}
+
 void GxEPD2_EPD::_endTransfer()
 {
   if (_cs >= 0) digitalWrite(_cs, HIGH);

--- a/src/GxEPD2_EPD.h
+++ b/src/GxEPD2_EPD.h
@@ -102,6 +102,7 @@ class GxEPD2_EPD
     void _writeCommandDataPGM(const uint8_t* pCommandData, uint8_t datalen);
     void _startTransfer();
     void _transfer(uint8_t value);
+    void _transferCommand(uint8_t value);
     void _endTransfer();
   protected:
     int16_t _cs, _dc, _rst, _busy, _busy_level;

--- a/src/GxEPD2_EPD.h
+++ b/src/GxEPD2_EPD.h
@@ -33,7 +33,7 @@ class GxEPD2_EPD
     GxEPD2_EPD(int16_t cs, int16_t dc, int16_t rst, int16_t busy, int16_t busy_level, uint32_t busy_timeout,
                uint16_t w, uint16_t h, GxEPD2::Panel p, bool c, bool pu, bool fpu);
     virtual void init(uint32_t serial_diag_bitrate = 0); // serial_diag_bitrate = 0 : disabled
-    virtual void init(uint32_t serial_diag_bitrate, bool initial, uint16_t reset_duration = 20, bool pulldown_rst_mode = false);
+    virtual void init(uint32_t serial_diag_bitrate, bool initial, uint16_t reset_duration = 20, bool pulldown_rst_mode = false, uint16_t reset_delay = 200, bool light_sleep = false);
     //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen
     virtual void clearScreen(uint8_t value) = 0; // init controller memory and screen (default white)
     virtual void writeScreenBuffer(uint8_t value) = 0; // init controller memory (default white)
@@ -106,11 +106,11 @@ class GxEPD2_EPD
   protected:
     int16_t _cs, _dc, _rst, _busy, _busy_level;
     uint32_t _busy_timeout;
-    bool _diag_enabled, _pulldown_rst_mode;
+    bool _diag_enabled, _pulldown_rst_mode, _busy_light_sleep;
     SPISettings _spi_settings;
     bool _initial_write, _initial_refresh;
     bool _power_is_on, _using_partial_mode, _hibernating;
-    uint16_t _reset_duration;
+    uint16_t _reset_duration, _reset_delay;
 };
 
 #endif


### PR DESCRIPTION
This change adds optional args to init()
in order to allow more efficient power use.

Tried to respect all defaults and modify the minimum
ammount the default codepath.

The reset delay allows to reduce in some boards
the amount waiting. ie _154_D67 works with 10ms (instead of 200ms)

The busy light sleep makes the active busy cycle use a 
power efficient light sleep + wakeup on the busy GPIO pin.
In total making the process 2ms slower,
but saving a lot of juicy active CPU power.

This is an example of difference of power usage vs current master.
On a 154_D67 device.

![LightSleep_ESP32](https://user-images.githubusercontent.com/6742754/142517492-6527c6aa-2d3b-4d10-ae4d-c51c4c828295.png)


Feel free to take the code if you think convenient.