### PR TITLE
Faster SPI transactions

### DIFF
--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -118,15 +118,17 @@ void GxEPD2_EPD::_reset()
 
 void GxEPD2_EPD::_waitWhileBusy(const char* comment, uint16_t busy_time)
 {
+#if defined(ESP8266) || defined(ESP32)
+  yield(); // avoid wdt
+#endif
   if (_busy >= 0)
   {
-    delay(1); // add some margin to become active
     unsigned long start = micros();
     while (1)
     {
       if (digitalRead(_busy) != _busy_level) break;
       if (_busy_callback) _busy_callback(_busy_callback_parameter);
-      else delay(1);
+      else delay(1); // add some margin to become active
       if (digitalRead(_busy) != _busy_level) break;
       if (micros() - start > _busy_timeout)
       {

--- a/src/GxEPD2_EPD.cpp
+++ b/src/GxEPD2_EPD.cpp
@@ -263,6 +263,13 @@ void GxEPD2_EPD::_transfer(uint8_t value)
   _pSPIx->transfer(value);
 }
 
+void GxEPD2_EPD::_transferCommand(uint8_t value)
+{
+  if (_dc >= 0) digitalWrite(_dc, LOW);
+  SPI.transfer(value);
+  if (_dc >= 0) digitalWrite(_dc, HIGH);
+}
+
 void GxEPD2_EPD::_endTransfer()
 {
   if (_cs >= 0) digitalWrite(_cs, HIGH);

--- a/src/GxEPD2_EPD.h
+++ b/src/GxEPD2_EPD.h
@@ -106,6 +106,7 @@ class GxEPD2_EPD
     void _writeCommandDataPGM(const uint8_t* pCommandData, uint8_t datalen);
     void _startTransfer();
     void _transfer(uint8_t value);
+    void _transferCommand(uint8_t value);
     void _endTransfer();
   protected:
     int16_t _cs, _dc, _rst, _busy, _busy_level;


### PR DESCRIPTION
This set of 4 commits optimize the SPI transfers, I only did it for 2 particulars Displays I have, but could be portable to others.
I am opening the PR for reference take if you want, (or not)

The "core" speed up occurs by using _transfer() in _writeImagePart() and _writeImage().
Here, we are sending lots of data bytes trough the SPI bus, and sending each byte separately adds too much overhead.
_writeByte() would do under the hood:
- beginTransaction(); 
- digitalWrite(_cs, LOW);
- spi_transfer();
- digitalWrite(_cs, HIGH);
- endTransaction();

It is better to pack it to avoid the cost of changing _cs LOW / HIGH repeatedly.

This might not show the same benefits on all arudino boards, will depend on the clock/CPU.
I can see a 2x speed up in ESP32 running @40MHz.
(Transaction on/off is also an extra overhead but not as much).