### PR TITLE
Fixed error: 'WIDTH_VISIBLE' is not a member of 

### DIFF
--- a/src/it8951/GxEPD2_it103_1872x1404.h
+++ b/src/it8951/GxEPD2_it103_1872x1404.h
@@ -24,6 +24,7 @@ class GxEPD2_it103_1872x1404 : public GxEPD2_EPD
   public:
     // attributes
     static const uint16_t WIDTH = 1872;
+    static const uint16_t WIDTH_VISIBLE = WIDTH;
     static const uint16_t HEIGHT = 1404;
     static const GxEPD2::Panel panel = GxEPD2::ES103TC1;
     static const bool hasColor = false;

--- a/src/it8951/GxEPD2_it60.h
+++ b/src/it8951/GxEPD2_it60.h
@@ -24,6 +24,7 @@ class GxEPD2_it60 : public GxEPD2_EPD
   public:
     // attributes
     static const uint16_t WIDTH = 800;
+    static const uint16_t WIDTH_VISIBLE = WIDTH;
     static const uint16_t HEIGHT = 600;
     static const GxEPD2::Panel panel = GxEPD2::ED060SCT;
     static const bool hasColor = false;

--- a/src/it8951/GxEPD2_it60_1448x1072.h
+++ b/src/it8951/GxEPD2_it60_1448x1072.h
@@ -24,6 +24,7 @@ class GxEPD2_it60_1448x1072 : public GxEPD2_EPD
   public:
     // attributes
     static const uint16_t WIDTH = 1448;
+    static const uint16_t WIDTH_VISIBLE = WIDTH;
     static const uint16_t HEIGHT = 1072;
     static const GxEPD2::Panel panel = GxEPD2::ED060KC1;
     static const bool hasColor = false;

--- a/src/it8951/GxEPD2_it78_1872x1404.h
+++ b/src/it8951/GxEPD2_it78_1872x1404.h
@@ -24,6 +24,7 @@ class GxEPD2_it78_1872x1404 : public GxEPD2_EPD
   public:
     // attributes
     static const uint16_t WIDTH = 1872;
+    static const uint16_t WIDTH_VISIBLE = WIDTH;
     static const uint16_t HEIGHT = 1404;
     static const GxEPD2::Panel panel = GxEPD2::ED078KC2;
     static const bool hasColor = false;


### PR DESCRIPTION
Hello,

After version 1.4.5 my project doesn't compile successfully.
I saw this error:

```
.pio/libdeps/esp32/GxEPD2/src/GxEPD2_3C.h:59:140: error: 'WIDTH_VISIBLE' is not a member of 'GxEPD2_it60'
     GxEPD2_3C(GxEPD2_Type epd2_instance) : GxEPD2_GFX_BASE_CLASS(epd2, GxEPD2_Type::WIDTH_VISIBLE, GxEPD2_Type::HEIGHT), epd2(epd2_instance)
```

So I found specific headers missing this line "**static const uint16_t WIDTH_VISIBLE = WIDTH;**"
I added it in the header and everything is compiled successfully.

I fix all of the headers for the **it8951**, but I'm not sure are this is required for the others, because I saw some headers missing this line.

Regards!