### PR TITLE
Add HTEW0154T8_V20 panel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/src/GxEPD2.h
+++ b/src/GxEPD2.h
@@ -38,6 +38,7 @@ class GxEPD2
       GDEW0102T4, Waveshare_1_02_bw = GDEW0102T4,
       GDEP015OC1, Waveshare_1_54_bw = GDEP015OC1,
       DEPG0150BN,
+      HTEW0154T8_V20,
       GDEH0154D67, Waveshare_1_54_bw_D67 = GDEH0154D67,
       GDEW0154T8,
       GDEW0154M09,

--- a/src/GxEPD2_BW.h
+++ b/src/GxEPD2_BW.h
@@ -33,6 +33,7 @@
 #include "GxEPD2_EPD.h"
 #include "epd/GxEPD2_102.h"
 #include "epd/GxEPD2_150_BN.h"
+#include "epd/GxEPD2_154_T8_V20.h"
 #include "epd/GxEPD2_154.h"
 #include "epd/GxEPD2_154_D67.h"
 #include "epd/GxEPD2_154_T8.h"

--- a/src/epd/GxEPD2_154_T8_V20.cpp
+++ b/src/epd/GxEPD2_154_T8_V20.cpp
@@ -14,18 +14,18 @@
 
 #include "GxEPD2_154_T8_V20.h"
 
-GxEPD2_160_BN::GxEPD2_160_BN(int16_t cs, int16_t dc, int16_t rst, int16_t busy) : GxEPD2_EPD(cs, dc, rst, busy, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+GxEPD2_154_T8_V20::GxEPD2_154_T8_V20(int16_t cs, int16_t dc, int16_t rst, int16_t busy) : GxEPD2_EPD(cs, dc, rst, busy, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
 {
 }
 
-void GxEPD2_160_BN::clearScreen(uint8_t value)
+void GxEPD2_154_T8_V20::clearScreen(uint8_t value)
 {
   writeScreenBuffer(value);
   refresh(true);
   writeScreenBufferAgain(value);
 }
 
-void GxEPD2_160_BN::writeScreenBuffer(uint8_t value)
+void GxEPD2_154_T8_V20::writeScreenBuffer(uint8_t value)
 {
   if (!_using_partial_mode)
     _Init_Part();
@@ -35,7 +35,7 @@ void GxEPD2_160_BN::writeScreenBuffer(uint8_t value)
   _initial_write = false;            // initial full screen buffer clean done
 }
 
-void GxEPD2_160_BN::writeScreenBufferAgain(uint8_t value)
+void GxEPD2_154_T8_V20::writeScreenBufferAgain(uint8_t value)
 {
   if (!_using_partial_mode)
     _Init_Part();
@@ -43,7 +43,7 @@ void GxEPD2_160_BN::writeScreenBufferAgain(uint8_t value)
   _writeScreenBuffer(0x24, value); // set current
 }
 
-void GxEPD2_160_BN::_writeScreenBuffer(uint8_t command, uint8_t value)
+void GxEPD2_154_T8_V20::_writeScreenBuffer(uint8_t command, uint8_t value)
 {
   _writeCommand(command);
   for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
@@ -52,24 +52,24 @@ void GxEPD2_160_BN::_writeScreenBuffer(uint8_t command, uint8_t value)
   }
 }
 
-void GxEPD2_160_BN::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm);
 }
 
-void GxEPD2_160_BN::writeImageForFullRefresh(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::writeImageForFullRefresh(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   _writeImage(0x26, bitmap, x, y, w, h, invert, mirror_y, pgm);
   _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm);
 }
 
-void GxEPD2_160_BN::writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   _writeImage(0x26, bitmap, x, y, w, h, invert, mirror_y, pgm); // set previous
   _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm); // set current
 }
 
-void GxEPD2_160_BN::_writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::_writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (_initial_write)
     writeScreenBuffer();                                          // initial full screen buffer clean
@@ -118,20 +118,20 @@ void GxEPD2_160_BN::_writeImage(uint8_t command, const uint8_t bitmap[], int16_t
   delay(1); // yield() to avoid WDT on ESP8266 and ESP32
 }
 
-void GxEPD2_160_BN::writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+void GxEPD2_154_T8_V20::writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
                                    int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   _writeImagePart(0x24, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
 }
 
-void GxEPD2_160_BN::writeImagePartAgain(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+void GxEPD2_154_T8_V20::writeImagePartAgain(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
                                         int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   _writeImagePart(0x26, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm); // set previous
   _writeImagePart(0x24, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm); // set current
 }
 
-void GxEPD2_160_BN::_writeImagePart(uint8_t command, const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+void GxEPD2_154_T8_V20::_writeImagePart(uint8_t command, const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
                                     int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (_initial_write)
@@ -190,7 +190,7 @@ void GxEPD2_160_BN::_writeImagePart(uint8_t command, const uint8_t bitmap[], int
   delay(1); // yield() to avoid WDT on ESP8266 and ESP32
 }
 
-void GxEPD2_160_BN::writeImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::writeImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (black)
   {
@@ -198,7 +198,7 @@ void GxEPD2_160_BN::writeImage(const uint8_t *black, const uint8_t *color, int16
   }
 }
 
-void GxEPD2_160_BN::writeImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+void GxEPD2_154_T8_V20::writeImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
                                    int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (black)
@@ -207,7 +207,7 @@ void GxEPD2_160_BN::writeImagePart(const uint8_t *black, const uint8_t *color, i
   }
 }
 
-void GxEPD2_160_BN::writeNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::writeNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (data1)
   {
@@ -215,14 +215,14 @@ void GxEPD2_160_BN::writeNative(const uint8_t *data1, const uint8_t *data2, int1
   }
 }
 
-void GxEPD2_160_BN::drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   writeImage(bitmap, x, y, w, h, invert, mirror_y, pgm);
   refresh(x, y, w, h);
   writeImageAgain(bitmap, x, y, w, h, invert, mirror_y, pgm);
 }
 
-void GxEPD2_160_BN::drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+void GxEPD2_154_T8_V20::drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   writeImagePart(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
@@ -230,7 +230,7 @@ void GxEPD2_160_BN::drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_
   writeImagePartAgain(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
 }
 
-void GxEPD2_160_BN::drawImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::drawImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (black)
   {
@@ -238,7 +238,7 @@ void GxEPD2_160_BN::drawImage(const uint8_t *black, const uint8_t *color, int16_
   }
 }
 
-void GxEPD2_160_BN::drawImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+void GxEPD2_154_T8_V20::drawImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (black)
@@ -247,7 +247,7 @@ void GxEPD2_160_BN::drawImagePart(const uint8_t *black, const uint8_t *color, in
   }
 }
 
-void GxEPD2_160_BN::drawNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+void GxEPD2_154_T8_V20::drawNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
 {
   if (data1)
   {
@@ -255,7 +255,7 @@ void GxEPD2_160_BN::drawNative(const uint8_t *data1, const uint8_t *data2, int16
   }
 }
 
-void GxEPD2_160_BN::refresh(bool partial_update_mode)
+void GxEPD2_154_T8_V20::refresh(bool partial_update_mode)
 {
   if (partial_update_mode)
     refresh(0, 0, WIDTH, HEIGHT);
@@ -268,7 +268,7 @@ void GxEPD2_160_BN::refresh(bool partial_update_mode)
   }
 }
 
-void GxEPD2_160_BN::refresh(int16_t x, int16_t y, int16_t w, int16_t h)
+void GxEPD2_154_T8_V20::refresh(int16_t x, int16_t y, int16_t w, int16_t h)
 {
   if (_initial_refresh)
     return refresh(false); // initial update needs be full update
@@ -292,12 +292,12 @@ void GxEPD2_160_BN::refresh(int16_t x, int16_t y, int16_t w, int16_t h)
   _Update_Part();
 }
 
-void GxEPD2_160_BN::powerOff()
+void GxEPD2_154_T8_V20::powerOff()
 {
   _PowerOff();
 }
 
-void GxEPD2_160_BN::hibernate()
+void GxEPD2_154_T8_V20::hibernate()
 {
   _PowerOff();
   if (_rst >= 0)
@@ -308,7 +308,7 @@ void GxEPD2_160_BN::hibernate()
   }
 }
 
-void GxEPD2_160_BN::_setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+void GxEPD2_154_T8_V20::_setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
 {
 
   x += 8;
@@ -330,7 +330,7 @@ void GxEPD2_160_BN::_setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint1
   _writeData(y / 256);
 }
 
-void GxEPD2_160_BN::_PowerOn()
+void GxEPD2_154_T8_V20::_PowerOn()
 {
   if (!_power_is_on)
   {
@@ -342,7 +342,7 @@ void GxEPD2_160_BN::_PowerOn()
   _power_is_on = true;
 }
 
-void GxEPD2_160_BN::_PowerOff()
+void GxEPD2_154_T8_V20::_PowerOff()
 {
   if (_power_is_on)
   {
@@ -355,7 +355,7 @@ void GxEPD2_160_BN::_PowerOff()
   _using_partial_mode = false;
 }
 
-void GxEPD2_160_BN::_InitDisplay()
+void GxEPD2_154_T8_V20::_InitDisplay()
 {
   if (_hibernating)
     _reset();
@@ -373,7 +373,7 @@ void GxEPD2_160_BN::_InitDisplay()
   _setPartialRamArea(0, 0, WIDTH, HEIGHT);
 }
 
-const unsigned char GxEPD2_160_BN::lut_partial[] PROGMEM =
+const unsigned char GxEPD2_154_T8_V20::lut_partial[] PROGMEM =
     {
         0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -394,14 +394,14 @@ const unsigned char GxEPD2_160_BN::lut_partial[] PROGMEM =
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x00, 0x00, 0x00};
 
-void GxEPD2_160_BN::_Init_Full()
+void GxEPD2_154_T8_V20::_Init_Full()
 {
   _InitDisplay();
   _PowerOn();
   _using_partial_mode = false;
 }
 
-void GxEPD2_160_BN::_Init_Part()
+void GxEPD2_154_T8_V20::_Init_Part()
 {
   _InitDisplay();
   _writeCommand(0x32);
@@ -410,7 +410,7 @@ void GxEPD2_160_BN::_Init_Part()
   _using_partial_mode = true;
 }
 
-void GxEPD2_160_BN::_Update_Full()
+void GxEPD2_154_T8_V20::_Update_Full()
 {
   _writeCommand(0x22);
   _writeData(0xf4);
@@ -418,7 +418,7 @@ void GxEPD2_160_BN::_Update_Full()
   _waitWhileBusy("_Update_Full", full_refresh_time);
 }
 
-void GxEPD2_160_BN::_Update_Part()
+void GxEPD2_154_T8_V20::_Update_Part()
 {
   _writeCommand(0x22);
   _writeData(0xfc);

--- a/src/epd/GxEPD2_154_T8_V20.cpp
+++ b/src/epd/GxEPD2_154_T8_V20.cpp
@@ -1,0 +1,427 @@
+// Display Library for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
+// Requires HW SPI and Adafruit_GFX. Caution: the e-paper panels require 3.3V supply AND data lines!
+//
+// based on Demo Example from Good Display, available here: http://www.e-paper-display.com/download_detail/downloadsId=806.html
+// Panel: HTEW0154T8_V20 : https://heltec.org/project/154-e-ink/
+// Controller : IL0373 : https://resource.heltec.cn/download/e-ink/154/1.54b%26w/HTEW0154T8_V20/IL0373.pdf
+// Display: HELTEC Automation 1.54 inch e-paper module : https://es.aliexpress.com/item/4000594878838.html
+//
+// Author: Jean-Marc Zingg
+// Edited: TheRoam by The Roaming Workshop
+// Version: see library.properties
+//
+// Library: https://github.com/ZinggJM/GxEPD2
+
+#include "GxEPD2_160_BN.h"
+
+GxEPD2_160_BN::GxEPD2_160_BN(int16_t cs, int16_t dc, int16_t rst, int16_t busy) : GxEPD2_EPD(cs, dc, rst, busy, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+{
+}
+
+void GxEPD2_160_BN::clearScreen(uint8_t value)
+{
+  writeScreenBuffer(value);
+  refresh(true);
+  writeScreenBufferAgain(value);
+}
+
+void GxEPD2_160_BN::writeScreenBuffer(uint8_t value)
+{
+  if (!_using_partial_mode)
+    _Init_Part();
+  if (_initial_write)
+    _writeScreenBuffer(0x26, value); // set previous
+  _writeScreenBuffer(0x24, value);   // set current
+  _initial_write = false;            // initial full screen buffer clean done
+}
+
+void GxEPD2_160_BN::writeScreenBufferAgain(uint8_t value)
+{
+  if (!_using_partial_mode)
+    _Init_Part();
+  _writeScreenBuffer(0x26, value); // set previous
+  _writeScreenBuffer(0x24, value); // set current
+}
+
+void GxEPD2_160_BN::_writeScreenBuffer(uint8_t command, uint8_t value)
+{
+  _writeCommand(command);
+  for (uint32_t i = 0; i < uint32_t(WIDTH) * uint32_t(HEIGHT) / 8; i++)
+  {
+    _writeData(value);
+  }
+}
+
+void GxEPD2_160_BN::writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_160_BN::writeImageForFullRefresh(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImage(0x26, bitmap, x, y, w, h, invert, mirror_y, pgm);
+  _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_160_BN::writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImage(0x26, bitmap, x, y, w, h, invert, mirror_y, pgm); // set previous
+  _writeImage(0x24, bitmap, x, y, w, h, invert, mirror_y, pgm); // set current
+}
+
+void GxEPD2_160_BN::_writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (_initial_write)
+    writeScreenBuffer();                                          // initial full screen buffer clean
+  delay(1);                                                       // yield() to avoid WDT on ESP8266 and ESP32
+  int16_t wb = (w + 7) / 8;                                       // width bytes, bitmaps are padded
+  x -= x % 8;                                                     // byte boundary
+  w = wb * 8;                                                     // byte boundary
+  int16_t x1 = x < 0 ? 0 : x;                                     // limit
+  int16_t y1 = y < 0 ? 0 : y;                                     // limit
+  int16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x;   // limit
+  int16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0))
+    return;
+  if (!_using_partial_mode)
+    _Init_Part();
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(command);
+  for (int16_t i = 0; i < h1; i++)
+  {
+    for (int16_t j = 0; j < w1 / 8; j++)
+    {
+      uint8_t data;
+      // use wb, h of bitmap for index!
+      int16_t idx = mirror_y ? j + dx / 8 + ((h - 1 - (i + dy))) * wb : j + dx / 8 + (i + dy) * wb;
+      if (pgm)
+      {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&bitmap[idx]);
+#else
+        data = bitmap[idx];
+#endif
+      }
+      else
+      {
+        data = bitmap[idx];
+      }
+      if (invert)
+        data = ~data;
+      _writeData(data);
+    }
+  }
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_160_BN::writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImagePart(0x24, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_160_BN::writeImagePartAgain(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                        int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  _writeImagePart(0x26, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm); // set previous
+  _writeImagePart(0x24, bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm); // set current
+}
+
+void GxEPD2_160_BN::_writeImagePart(uint8_t command, const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                    int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (_initial_write)
+    writeScreenBuffer(); // initial full screen buffer clean
+  delay(1);              // yield() to avoid WDT on ESP8266 and ESP32
+  if ((w_bitmap < 0) || (h_bitmap < 0) || (w < 0) || (h < 0))
+    return;
+  if ((x_part < 0) || (x_part >= w_bitmap))
+    return;
+  if ((y_part < 0) || (y_part >= h_bitmap))
+    return;
+  int16_t wb_bitmap = (w_bitmap + 7) / 8;                         // width bytes, bitmaps are padded
+  x_part -= x_part % 8;                                           // byte boundary
+  w = w_bitmap - x_part < w ? w_bitmap - x_part : w;              // limit
+  h = h_bitmap - y_part < h ? h_bitmap - y_part : h;              // limit
+  x -= x % 8;                                                     // byte boundary
+  w = 8 * ((w + 7) / 8);                                          // byte boundary, bitmaps are padded
+  int16_t x1 = x < 0 ? 0 : x;                                     // limit
+  int16_t y1 = y < 0 ? 0 : y;                                     // limit
+  int16_t w1 = x + w < int16_t(WIDTH) ? w : int16_t(WIDTH) - x;   // limit
+  int16_t h1 = y + h < int16_t(HEIGHT) ? h : int16_t(HEIGHT) - y; // limit
+  int16_t dx = x1 - x;
+  int16_t dy = y1 - y;
+  w1 -= dx;
+  h1 -= dy;
+  if ((w1 <= 0) || (h1 <= 0))
+    return;
+  if (!_using_partial_mode)
+    _Init_Part();
+  _setPartialRamArea(x1, y1, w1, h1);
+  _writeCommand(command);
+  for (int16_t i = 0; i < h1; i++)
+  {
+    for (int16_t j = 0; j < w1 / 8; j++)
+    {
+      uint8_t data;
+      // use wb_bitmap, h_bitmap of bitmap for index!
+      int16_t idx = mirror_y ? x_part / 8 + j + dx / 8 + ((h_bitmap - 1 - (y_part + i + dy))) * wb_bitmap : x_part / 8 + j + dx / 8 + (y_part + i + dy) * wb_bitmap;
+      if (pgm)
+      {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&bitmap[idx]);
+#else
+        data = bitmap[idx];
+#endif
+      }
+      else
+      {
+        data = bitmap[idx];
+      }
+      if (invert)
+        data = ~data;
+      _writeData(data);
+    }
+  }
+  delay(1); // yield() to avoid WDT on ESP8266 and ESP32
+}
+
+void GxEPD2_160_BN::writeImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    writeImage(black, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_160_BN::writeImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                   int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    writeImagePart(black, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_160_BN::writeNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (data1)
+  {
+    writeImage(data1, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_160_BN::drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImage(bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImageAgain(bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_160_BN::drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                  int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImagePart(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+  writeImagePartAgain(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_160_BN::drawImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    drawImage(black, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_160_BN::drawImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                                  int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (black)
+  {
+    drawImagePart(black, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_160_BN::drawNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (data1)
+  {
+    drawImage(data1, x, y, w, h, invert, mirror_y, pgm);
+  }
+}
+
+void GxEPD2_160_BN::refresh(bool partial_update_mode)
+{
+  if (partial_update_mode)
+    refresh(0, 0, WIDTH, HEIGHT);
+  else
+  {
+    if (_using_partial_mode)
+      _Init_Full();
+    _Update_Full();
+    _initial_refresh = false; // initial full update done
+  }
+}
+
+void GxEPD2_160_BN::refresh(int16_t x, int16_t y, int16_t w, int16_t h)
+{
+  if (_initial_refresh)
+    return refresh(false); // initial update needs be full update
+  // intersection with screen
+  int16_t w1 = x < 0 ? w + x : w;                             // reduce
+  int16_t h1 = y < 0 ? h + y : h;                             // reduce
+  int16_t x1 = x < 0 ? 0 : x;                                 // limit
+  int16_t y1 = y < 0 ? 0 : y;                                 // limit
+  w1 = x1 + w1 < int16_t(WIDTH) ? w1 : int16_t(WIDTH) - x1;   // limit
+  h1 = y1 + h1 < int16_t(HEIGHT) ? h1 : int16_t(HEIGHT) - y1; // limit
+  if ((w1 <= 0) || (h1 <= 0))
+    return;
+  // make x1, w1 multiple of 8
+  w1 += x1 % 8;
+  if (w1 % 8 > 0)
+    w1 += 8 - w1 % 8;
+  x1 -= x1 % 8;
+  if (!_using_partial_mode)
+    _Init_Part();
+  _setPartialRamArea(x1, y1, w1, h1);
+  _Update_Part();
+}
+
+void GxEPD2_160_BN::powerOff()
+{
+  _PowerOff();
+}
+
+void GxEPD2_160_BN::hibernate()
+{
+  _PowerOff();
+  if (_rst >= 0)
+  {
+    _writeCommand(0x10); // deep sleep mode
+    _writeData(0x1);     // enter deep sleep
+    _hibernating = true;
+  }
+}
+
+void GxEPD2_160_BN::_setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+{
+
+  x += 8;
+
+  _writeCommand(0x11); // set ram entry mode
+  _writeData(0x03);    // x increase, y increase : normal mode
+  _writeCommand(0x44);
+  _writeData(x / 8);
+  _writeData((x + w - 1) / 8);
+  _writeCommand(0x45);
+  _writeData(y % 256);
+  _writeData(y / 256);
+  _writeData((y + h - 1) % 256);
+  _writeData((y + h - 1) / 256);
+  _writeCommand(0x4e);
+  _writeData(x / 8);
+  _writeCommand(0x4f);
+  _writeData(y % 256);
+  _writeData(y / 256);
+}
+
+void GxEPD2_160_BN::_PowerOn()
+{
+  if (!_power_is_on)
+  {
+    _writeCommand(0x22);
+    _writeData(0xf8);
+    _writeCommand(0x20);
+    _waitWhileBusy("_PowerOn", power_on_time);
+  }
+  _power_is_on = true;
+}
+
+void GxEPD2_160_BN::_PowerOff()
+{
+  if (_power_is_on)
+  {
+    _writeCommand(0x22);
+    _writeData(0x83);
+    _writeCommand(0x20);
+    _waitWhileBusy("_PowerOff", power_off_time);
+  }
+  _power_is_on = false;
+  _using_partial_mode = false;
+}
+
+void GxEPD2_160_BN::_InitDisplay()
+{
+  if (_hibernating)
+    _reset();
+  delay(10);           // 10ms according to specs
+  _writeCommand(0x12); // soft reset
+  delay(10);           // 10ms according to specs
+  _writeCommand(0x01); // Driver output control
+  _writeData(0xC7);
+  _writeData(0x00);
+  _writeData(0x00);
+  _writeCommand(0x3C); // BorderWavefrom
+  _writeData(0x05);
+  _writeCommand(0x18); // Read built-in temperature sensor
+  _writeData(0x80);
+  _setPartialRamArea(0, 0, WIDTH, HEIGHT);
+}
+
+const unsigned char GxEPD2_160_BN::lut_partial[] PROGMEM =
+    {
+        0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x40, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x00, 0x00, 0x00};
+
+void GxEPD2_160_BN::_Init_Full()
+{
+  _InitDisplay();
+  _PowerOn();
+  _using_partial_mode = false;
+}
+
+void GxEPD2_160_BN::_Init_Part()
+{
+  _InitDisplay();
+  _writeCommand(0x32);
+  _writeDataPGM(lut_partial, sizeof(lut_partial));
+  _PowerOn();
+  _using_partial_mode = true;
+}
+
+void GxEPD2_160_BN::_Update_Full()
+{
+  _writeCommand(0x22);
+  _writeData(0xf4);
+  _writeCommand(0x20);
+  _waitWhileBusy("_Update_Full", full_refresh_time);
+}
+
+void GxEPD2_160_BN::_Update_Part()
+{
+  _writeCommand(0x22);
+  _writeData(0xfc);
+  _writeCommand(0x20);
+  _waitWhileBusy("_Update_Part", partial_refresh_time);
+}

--- a/src/epd/GxEPD2_154_T8_V20.cpp
+++ b/src/epd/GxEPD2_154_T8_V20.cpp
@@ -12,7 +12,7 @@
 //
 // Library: https://github.com/ZinggJM/GxEPD2
 
-#include "GxEPD2_160_BN.h"
+#include "GxEPD2_154_T8_V20.h"
 
 GxEPD2_160_BN::GxEPD2_160_BN(int16_t cs, int16_t dc, int16_t rst, int16_t busy) : GxEPD2_EPD(cs, dc, rst, busy, HIGH, 10000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
 {

--- a/src/epd/GxEPD2_154_T8_V20.h
+++ b/src/epd/GxEPD2_154_T8_V20.h
@@ -1,0 +1,86 @@
+// Display Library for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
+// Requires HW SPI and Adafruit_GFX. Caution: the e-paper panels require 3.3V supply AND data lines!
+//
+// based on Demo Example from Good Display, available here: http://www.e-paper-display.com/download_detail/downloadsId=806.html
+// Panel: HTEW0154T8_V20 : https://heltec.org/project/154-e-ink/
+// Controller : IL0373 : https://resource.heltec.cn/download/e-ink/154/1.54b%26w/HTEW0154T8_V20/IL0373.pdf
+// Display: HELTEC Automation 1.54 inch e-paper module : https://es.aliexpress.com/item/4000594878838.html
+//
+// Author: Jean-Marc Zingg
+// Edited: TheRoam by The Roaming Workshop
+// Version: see library.properties
+//
+// Library: https://github.com/ZinggJM/GxEPD2
+
+#ifndef _GxEPD2_160_BN_H_
+#define _GxEPD2_160_BN_H_
+
+#include "../GxEPD2_EPD.h"
+
+class GxEPD2_160_BN : public GxEPD2_EPD
+{
+public:
+  // attributes
+  static const uint16_t WIDTH = 160;
+  static const uint16_t HEIGHT = 160;
+  static const GxEPD2::Panel panel = GxEPD2::HTEW0154T8_V20;
+  static const bool hasColor = false;
+  static const bool hasPartialUpdate = true;
+  static const bool hasFastPartialUpdate = true;
+  static const uint16_t power_on_time = 100;        // ms, e.g. 94000us
+  static const uint16_t power_off_time = 150;       // ms, e.g. 140000us
+  static const uint16_t full_refresh_time = 2500;   // ms, e.g. 3825000us
+  static const uint16_t partial_refresh_time = 350; // ms, e.g. 736000us
+  // constructor
+  GxEPD2_160_BN(int16_t cs, int16_t dc, int16_t rst, int16_t busy);
+  // methods (virtual)
+  //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen
+  void clearScreen(uint8_t value = 0xFF);            // init controller memory and screen (default white)
+  void writeScreenBuffer(uint8_t value = 0xFF);      // init controller memory (default white)
+  void writeScreenBufferAgain(uint8_t value = 0xFF); // init previous buffer controller memory (default white)
+  // write to controller memory, without screen refresh; x and w should be multiple of 8
+  void writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void writeImageForFullRefresh(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                      int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void writeImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void writeImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                      int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  // for differential update: set current and previous buffers equal (for fast partial update to work correctly)
+  void writeImageAgain(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void writeImagePartAgain(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                           int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  // write sprite of native data to controller memory, without screen refresh; x and w should be multiple of 8
+  void writeNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  // write to controller memory, with screen refresh; x and w should be multiple of 8
+  void drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                     int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void drawImage(const uint8_t *black, const uint8_t *color, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void drawImagePart(const uint8_t *black, const uint8_t *color, int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                     int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  // write sprite of native data to controller memory, with screen refresh; x and w should be multiple of 8
+  void drawNative(const uint8_t *data1, const uint8_t *data2, int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void refresh(bool partial_update_mode = false);           // screen refresh from controller memory to full screen
+  void refresh(int16_t x, int16_t y, int16_t w, int16_t h); // screen refresh from controller memory, partial screen
+  void powerOff();                                          // turns off generation of panel driving voltages, avoids screen fading over time
+  void hibernate();                                         // turns powerOff() and sets controller to deep sleep for minimum power use, ONLY if wakeable by RST (rst >= 0)
+private:
+  void _writeScreenBuffer(uint8_t command, uint8_t value);
+  void _writeImage(uint8_t command, const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void _writeImagePart(uint8_t command, const uint8_t bitmap[], int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h, bool invert = false, bool mirror_y = false, bool pgm = false);
+  void _setPartialRamArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  void _PowerOn();
+  void _PowerOff();
+  void _InitDisplay();
+  void _Init_Full();
+  void _Init_Part();
+  void _Update_Full();
+  void _Update_Part();
+
+private:
+  static const unsigned char lut_partial[];
+};
+
+#endif

--- a/src/epd/GxEPD2_154_T8_V20.h
+++ b/src/epd/GxEPD2_154_T8_V20.h
@@ -12,12 +12,12 @@
 //
 // Library: https://github.com/ZinggJM/GxEPD2
 
-#ifndef _GxEPD2_160_BN_H_
-#define _GxEPD2_160_BN_H_
+#ifndef _GxEPD2_154_T8_V20_H_
+#define _GxEPD2_154_T8_V20_H_
 
 #include "../GxEPD2_EPD.h"
 
-class GxEPD2_160_BN : public GxEPD2_EPD
+class GxEPD2_154_T8_V20 : public GxEPD2_EPD
 {
 public:
   // attributes
@@ -32,7 +32,7 @@ public:
   static const uint16_t full_refresh_time = 2500;   // ms, e.g. 3825000us
   static const uint16_t partial_refresh_time = 350; // ms, e.g. 736000us
   // constructor
-  GxEPD2_160_BN(int16_t cs, int16_t dc, int16_t rst, int16_t busy);
+  GxEPD2_154_T8_V20(int16_t cs, int16_t dc, int16_t rst, int16_t busy);
   // methods (virtual)
   //  Support for Bitmaps (Sprites) to Controller Buffer and to Screen
   void clearScreen(uint8_t value = 0xFF);            // init controller memory and screen (default white)


### PR DESCRIPTION
This adds support for the Heltec 1.54" V2 panel HTEW0154T8_V20 with 152x152 resolution. The resolution was set to 160x160, because of the IL0373 controller.

An 8 pixel offset on the x-axis, defined in `GxEPD2_154_T8_V20::_setPartialRamArea` fixes the problem of the 8 leftmost pixels being outside the displays boundaries.