### PR TITLE
Update GxEPD2_750c_Z08.h

### DIFF
--- a/src/epd3c/GxEPD2_750c_Z08.h
+++ b/src/epd3c/GxEPD2_750c_Z08.h
@@ -30,7 +30,7 @@ class GxEPD2_750c_Z08 : public GxEPD2_EPD
     static const bool hasFastPartialUpdate = false;
     static const uint16_t power_on_time = 150; // ms, e.g. 133421us
     static const uint16_t power_off_time = 30; // ms, e.g. 25362us
-    static const uint16_t full_refresh_time = 18000; // ms, e.g. 17133490us
+    static const uint16_t full_refresh_time = 42000; // ms, e.g. 17133490us
     static const uint16_t partial_refresh_time = 18000; // ms, e.g. 17133490us
     // constructor
     GxEPD2_750c_Z08(int16_t cs, int16_t dc, int16_t rst, int16_t busy);


### PR DESCRIPTION
I don't know where you got the 18s for the full refresh time for this display, but it's completely wrong. WaveShare's documentation says 26s, however I have observed around 32s with the most recent ones ("V3") and up to 40s on older ones ("V2") and I remember it used to be documented as 40 or 39 seconds. I did test test it and I was getting systematically "busy timeout" with your library.