### PR TITLE
Fix busy timeout for 7.5 inch b/w/r 800x480 display

### DIFF
--- a/src/epd3c/GxEPD2_750c_Z08.cpp
+++ b/src/epd3c/GxEPD2_750c_Z08.cpp
@@ -14,7 +14,7 @@
 #include "GxEPD2_750c_Z08.h"
 
 GxEPD2_750c_Z08::GxEPD2_750c_Z08(int16_t cs, int16_t dc, int16_t rst, int16_t busy) :
-  GxEPD2_EPD(cs, dc, rst, busy, LOW, 20000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
+  GxEPD2_EPD(cs, dc, rst, busy, LOW, 42000000, WIDTH, HEIGHT, panel, hasColor, hasPartialUpdate, hasFastPartialUpdate)
 {
 }
 

--- a/src/epd3c/GxEPD2_750c_Z08.h
+++ b/src/epd3c/GxEPD2_750c_Z08.h
@@ -30,7 +30,7 @@ class GxEPD2_750c_Z08 : public GxEPD2_EPD
     static const bool hasFastPartialUpdate = false;
     static const uint16_t power_on_time = 150; // ms, e.g. 133421us
     static const uint16_t power_off_time = 30; // ms, e.g. 25362us
-    static const uint16_t full_refresh_time = 18000; // ms, e.g. 17133490us
+    static const uint16_t full_refresh_time = 42000; // ms, e.g. 17133490us
     static const uint16_t partial_refresh_time = 18000; // ms, e.g. 17133490us
     // constructor
     GxEPD2_750c_Z08(int16_t cs, int16_t dc, int16_t rst, int16_t busy);


### PR DESCRIPTION
This display (GDEW075Z08) has a full refresh time of about 26 seconds I think, I don't remember the exact time now, but way more than 18 seconds.
I have no idea where you got the 18 seconds, but it was not enough. It kind of worked with black-and-white-only images (because the black and white is done first, and then you interrupt it while it's doing the red which is doing nothing if both the old and the new image  only have black and white). In fact, for several weeks I used it only with black-n-white images and I didn't even notice that I was systematically getting busy timeout on every full refresh because of this bug; the images looked good. But I have no idea about the side effects of interrupting the refresh half-way when only the black and white have been properly been updated.

I put in 40 seconds in my version, but I was mixing it up with the GDEW075Z09. 27 should be enough for this one. The GDEW075Z09 is slower, or at least the yellow variant is (not sure about the red one). And I haven't checked what timeout you currently have for the GDEW075Z09.

I know you'll reject the PR but I hope you look into it and apply the fix in whatever way you see fit.